### PR TITLE
prefer-oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,28 @@ raises `Excon::Error` exceptions when errors occur.  You can catch specific
 ### A real world example
 
 Let's go through an example of creating an app and using the API to work with
-it.  The first thing you need is a client that's setup with your API token.
-You can find your API token by clicking the *Show API Key* on your
-[account page](https://dashboard.heroku.com/account).
+it.  The first thing you need is a client setup with an OAuth token.  You can
+create an OAuth token using the `heroku-oauth` toolbelt plugin:
+
+```bash
+$ heroku plugins:install git@github.com:heroku/heroku-oauth.git
+$ heroku authorizations:create -d "Platform API example token"
+Created OAuth authorization.
+  ID:          2f01aac0-e9d3-4773-af4e-3e510aa006ca
+  Description: Platform API example token
+  Scope:       global
+  Token:       e7dd6ad7-3c6a-411e-a2be-c9fe52ac7ed2
+```
+
+Use the `Token` value when instantiating a client:
 
 ```ruby
 require 'platform-api'
-heroku = PlatformAPI.connect('token')
+heroku = PlatformAPI.connect_oauth('e7dd6ad7-3c6a-411e-a2be-c9fe52ac7ed2')
 ```
+
+The [OAuth article]()https://devcenter.heroku.com/articles/oauth has more information about OAuth tokens, including how to
+create tokens with specific scopes.
 
 Now let's create an app:
 

--- a/lib/platform-api/client.rb
+++ b/lib/platform-api/client.rb
@@ -1,6 +1,20 @@
 module PlatformAPI
-  # Get a client configured with the specified token.
-  def self.connect( token)
+  # Get a client configured with the specified OAuth token.
+  def self.connect_oauth(oauth_token)
+    url = "https://api.heroku.com"
+    default_headers = {'Accept' => 'application/vnd.heroku+json; version=3'}
+    cache = Moneta.new(:File, dir: "#{Dir.home}/.heroku/platform-api")
+    options = {default_headers: default_headers, cache: cache}
+    schema_json = File.read("#{File.dirname(__FILE__)}/schema.json")
+    schema = Heroics::Schema.new(MultiJson.decode(schema_json))
+    Heroics.oauth_client_from_schema(oauth_token, schema, url, options)
+  end
+
+  # Get a client configured with the specified API token.
+  #
+  # Always prefer `connect_oauth` unless there's a very good reason you must
+  # use a non-OAuth API token.
+  def self.connect(token)
     url = "https://:#{token}@api.heroku.com"
     default_headers = {'Accept' => 'application/vnd.heroku+json; version=3'}
     cache = Moneta.new(:File, dir: "#{Dir.home}/.heroku/platform-api")

--- a/lib/platform-api/version.rb
+++ b/lib/platform-api/version.rb
@@ -1,3 +1,3 @@
 module PlatformAPI
-  VERSION = '0.0.5'
+  VERSION = '0.0.6'
 end

--- a/platform-api.gemspec
+++ b/platform-api.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
 
-  spec.add_dependency 'heroics', '~> 0.0.4'
+  spec.add_dependency 'heroics', '~> 0.0.5'
 end


### PR DESCRIPTION
- A new `PlatformAPI.connect_oauth` function creates a Heroics
  `Client` configured to use an OAuth token.
- The setup instructions `README.md` describe setting up a client with
  an OAuth token, instead of basic auth.
- Bumped version.
