### PR TITLE
add min vesrion for heroics

### DIFF
--- a/platform-api.gemspec
+++ b/platform-api.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'yard'
 
-  spec.add_dependency 'heroics'
+  spec.add_dependency 'heroics', '~> 0.0.16'
 end


### PR DESCRIPTION
@jkakar - heroics 0.0.6 throws undefined method errors. 0.0.16 (latest) doesn't.