### PR TITLE
Fix error class for catching errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ description of all available resources and methods.
 ### Handling errors
 
 The client uses [Excon](https://github.com/geemus/excon) under the hood and
-raises `Excon::Error` exceptions when errors occur.  You can catch specific
+raises `Excon::Errors::Error` exceptions when errors occur.  You can catch specific
 [Excon error types](https://github.com/geemus/excon/blob/master/lib/excon/errors.rb) if you want.
 
 ### A real world example


### PR DESCRIPTION
In the README, it says `Excon::Error`, but it should be `Excon::Errors::Error`