### PR TITLE
Add moneta as a dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,21 +3,19 @@ PATH
   specs:
     platform-api (0.8.0)
       heroics (~> 0.0.17)
+      moneta (~> 0.8.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     erubis (2.7.0)
-    excon (0.49.0)
-    heroics (0.0.17)
+    excon (0.55.0)
+    heroics (0.0.18)
       erubis (~> 2.0)
       excon
-      moneta
       multi_json (>= 1.9.2)
-      netrc
-    moneta (0.8.0)
+    moneta (0.8.1)
     multi_json (1.12.1)
-    netrc (0.11.0)
     rake (10.5.0)
     yard (0.8.7.6)
 
@@ -31,4 +29,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.11.2
+   1.13.7

--- a/lib/platform-api.rb
+++ b/lib/platform-api.rb
@@ -1,4 +1,5 @@
 require 'heroics'
+require 'moneta'
 
 # Ruby HTTP client for the Heroku API.
 module PlatformAPI

--- a/platform-api.gemspec
+++ b/platform-api.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard'
 
   spec.add_dependency 'heroics', '~> 0.0.17'
+  spec.add_dependency 'moneta', '~> 0.8.1'
 end


### PR DESCRIPTION
Looks like `heroics` stopped requiring `moneta` by default. Seeing as how we explicitly use `moneta` (`client:48`) we should assume `moneta` is a hard dependency as `platform-api` will not work without it.

This PR adds Moneta as a dependency in the Gemfile and requires it at runtime.

I *think* this is the PR that introduced the issue https://github.com/interagent/heroics/commit/79b38ee63d2eaaf3c31eb2999bbec279c671a0df