### PR TITLE
Use heroics 0.0.21, load the config and the schema file at runtime to correctly map schema attributes used in metaprogramming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .yardoc
 doc/
 pkg/
+spec/examples.txt

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,29 @@
 PATH
   remote: .
   specs:
-    platform-api (1.0.0)
-      heroics (~> 0.0.20)
+    platform-api (1.0.1)
+      heroics (~> 0.0.21)
       moneta (~> 0.8.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.1)
     erubis (2.7.0)
     excon (0.55.0)
-    heroics (0.0.20)
+    heroics (0.0.21)
       erubis (~> 2.0)
       excon
       multi_json (>= 1.9.2)
+    method_source (0.8.2)
     moneta (0.8.1)
     multi_json (1.12.1)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rake (10.5.0)
+    slop (3.6.0)
     yard (0.8.7.6)
 
 PLATFORMS
@@ -25,6 +32,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.3)
   platform-api!
+  pry
   rake
   yard
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.1)
+    diff-lcs (1.3)
     erubis (2.7.0)
     excon (0.55.0)
     heroics (0.0.21)
@@ -18,11 +19,25 @@ GEM
     method_source (0.8.2)
     moneta (0.8.1)
     multi_json (1.12.1)
+    netrc (0.11.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rake (10.5.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
     slop (3.6.0)
     yard (0.8.7.6)
 
@@ -31,9 +46,11 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.3)
+  netrc
   platform-api!
   pry
   rake
+  rspec
   yard
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -312,6 +312,10 @@ Remember to commit and push the changes to Github.
 
 * This project follows [semver](http://semver.org) from version 1.0.0. Please
   be sure to keep this in mind if you're the project maintainer.
+* Be sure to run the very basic acceptance rspecs. The rspecs will attempt
+  to parse your oauth token for `api.heroku.com` from your `.netrc`. You can
+  optionally use the `OAUTH_TOKEN` and `ACCOUNT_EMAIL` environment variables.
+  They don't mutate anything but they might in the future.
 * Bump the version in `lib/platform-api/version.rb`
 * `bundle install` to update Gemfile.lock
 * `git commit -m 'vX.Y.Z' to stage the version and Gemfile.lock changes

--- a/Rakefile
+++ b/Rakefile
@@ -22,3 +22,10 @@ task :publish do
   sh 'git push origin gh-pages'
   sh 'git checkout master'
 end
+
+begin
+  require "rspec/core/rake_task"
+  RSpec::Core::RakeTask.new(:spec)
+  task default: [:spec]
+rescue LoadError
+end

--- a/config/client-config.rb
+++ b/config/client-config.rb
@@ -4,12 +4,14 @@ require 'heroics'
 Heroics.default_configuration do |config|
   config.base_url = 'https://api.heroku.com'
   config.module_name = 'PlatformAPI'
-  config.schema_filepath = 'schema.json'
+  config.schema_filepath = File.join(File.expand_path('../..', __FILE__), 'schema.json')
 
   config.headers = { 'Accept' => 'application/vnd.heroku+json; version=3' }
   config.ruby_name_replacement_patterns = {
     /add[^a-z]+on/i => 'addon',
     /[\s-]+/ => '_',
   }
+  # This needs to be in single quotes to avoid interpolation during the client
+  # build
   config.cache_path = '#{Dir.home}/.heroics/platform-api'
 end

--- a/lib/platform-api.rb
+++ b/lib/platform-api.rb
@@ -1,6 +1,7 @@
 require 'heroics'
 require 'moneta'
 
+require_relative '../config/client-config'
 # Ruby HTTP client for the Heroku API.
 module PlatformAPI
 end

--- a/lib/platform-api/version.rb
+++ b/lib/platform-api/version.rb
@@ -1,3 +1,3 @@
 module PlatformAPI
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/platform-api.gemspec
+++ b/platform-api.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'netrc'
+  spec.add_development_dependency 'rspec'
 
   spec.add_dependency 'heroics', '~> 0.0.21'
   spec.add_dependency 'moneta', '~> 0.8.1'

--- a/platform-api.gemspec
+++ b/platform-api.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'yard'
+  spec.add_development_dependency 'pry'
 
-  spec.add_dependency 'heroics', '~> 0.0.20'
+  spec.add_dependency 'heroics', '~> 0.0.21'
   spec.add_dependency 'moneta', '~> 0.8.1'
 end

--- a/spec/acceptance/generated_client_spec.rb
+++ b/spec/acceptance/generated_client_spec.rb
@@ -1,0 +1,70 @@
+require 'netrc'
+require 'platform-api'
+
+describe 'The generated platform api client' do
+  it "can get account info" do
+    expect(client.account.info(email)).not_to be_empty
+  end
+
+  it "can get addon info for an app" do
+    expect(client.addon.list_by_app(an_app['name'])).not_to be_empty
+  end
+
+  it "can list apps" do
+    expect(client.app.list).not_to be_empty
+  end
+
+  it "can get app info" do
+    expect(client.app.info(an_app['name'])).to eq an_app
+  end
+
+  it "can get build info" do
+    expect(client.build.list(an_app['name'])).not_to be_empty
+  end
+
+  it "can get config vars" do
+    expect(client.config_var.info_for_app(an_app['name'])).not_to be_empty
+  end
+
+  it "can get domain list and info" do
+    domains = client.domain.list(an_app['name'])
+    expect(domains).not_to be_empty
+
+    expect(client.domain.info(an_app['name'], domains.first['hostname'])).not_to be_empty
+  end
+
+  it "can get dyno sizes" do
+    expect(client.dyno_size.list).not_to be_empty
+  end
+
+  it "can get add-on plan info" do
+    expect(client.plan.list('heroku-postgresql')).not_to be_empty
+  end
+
+  it "can get release info" do
+    expect(client.release.list(an_app['name'])).not_to be_empty
+  end
+
+  def an_app
+    @app ||= client.app.list.first
+  end
+
+  def email
+    @email
+  end
+
+  def client
+    @client ||=
+      begin
+        entry = Netrc.read['api.heroku.com']
+        if entry
+          oauth_token = entry.password
+          @email = entry.login
+        else
+          oauth_token = ENV['OAUTH_TOKEN']
+          @email = ENV['ACCOUNT_EMAIL']
+        end
+        PlatformAPI.connect_oauth(oauth_token)
+      end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,20 @@
+require 'pry'
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.filter_run_when_matching :focus
+  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.warnings = true
+  if config.files_to_run.one?
+    config.default_formatter = 'doc'
+  end
+  config.order = :random
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
I'm a dipshit and accidentally pushed this to master before submitting this PR. We could probably force push it off but I don't really care about a little churn in the history.

Otherwise, in terms of what this does, it uses the newly fixed heroics release and ensures the config and schema are loaded so that the config is the same during metaprogramming.