### PR TITLE
Update README.md: replace heroku.config_var.info with heroku_config_v…

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ heroku.addon.create('floating-retreat-4255', {'plan' => 'heroku-postgresql:dev'}
 Excellent!  That will have added a config var which we can now see:
 
 ```ruby
-heroku.config_var.info('floating-retreat-4255')
+heroku.config_var.info_for_app('floating-retreat-4255')
 => {"HEROKU_POSTGRESQL_COBALT_URL"=>"postgres://<redacted>"}
 ```
 


### PR DESCRIPTION
…ar.info_for_app

Hello!

I think the `heroku.config_var.info` api has changed to `info_for_app`, as seen here: http://heroku.github.io/platform-api/PlatformAPI/ConfigVar.html