### PR TITLE
Upgrade to using the latest `moneta v1.0.0` gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     platform-api (2.1.0)
       heroics (~> 0.0.23)
-      moneta (~> 0.8.1)
+      moneta (~> 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -17,7 +17,7 @@ GEM
       excon
       multi_json (>= 1.9.2)
     method_source (0.8.2)
-    moneta (0.8.1)
+    moneta (1.0.0)
     multi_json (1.12.1)
     netrc (0.11.0)
     pry (0.10.4)
@@ -54,4 +54,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/platform-api.gemspec
+++ b/platform-api.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
 
   spec.add_dependency 'heroics', '~> 0.0.23'
-  spec.add_dependency 'moneta', '~> 0.8.1'
+  spec.add_dependency 'moneta', '~> 1.0.0'
 end


### PR DESCRIPTION
Hey. Thank you for all of your work on this `platform-api` gem!

This is just a quick PR to upgrade the `moneta` gem to `v1.0.0` which came out in March 2017. I am using another gem in conjunction with this one which caused a dependency conflict. I forked this, upgraded `moneta`, and everything seems to be working fine. Now that I think about it, perhaps it should be `moneta >= 0.8.1`. What are your thoughts?

As a caveat, I should let you know that even before changing the version, the spec tests here were failing locally. I am not sure if that's something specific to my machine, or what. So unfortunately I can't say "it works in all cases". Perhaps that is something that you would be more informed about than I am.

Either way, thanks again. Let me know if I can help with anything.