### PR TITLE
Relax moneta version dependency

### DIFF
--- a/platform-api.gemspec
+++ b/platform-api.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
 
   spec.add_dependency 'heroics', '~> 0.0.25'
-  spec.add_dependency 'moneta', '~> 1.0.0'
+  spec.add_dependency 'moneta', '~> 1.0'
 end


### PR DESCRIPTION
Moneta uses semantic versioning since version 1.0.0.