### PR TITLE
Allow explicit app test name

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For example, to get information about the `web` formation on the `sushi` app
 you'd invoke `heroku.formation.info('sushi', 'web')` and it would return a
 Ruby object that matches the one given in the [response example](https://devcenter.heroku.com/articles/platform-api-reference#formation-info).
 
-The [API documentation](http://heroku.github.io/platform-api/_index.html) contains a 
+The [API documentation](http://heroku.github.io/platform-api/_index.html) contains a
 description of all available resources and methods.
 
 ### Handling errors
@@ -357,3 +357,20 @@ You can see it live on [Github Pages](http://heroku.github.io/platform-api/).
 3. Commit your changes: `git commit -am 'Add some feature'`
 4. Push to the branch: `git push origin my-new-feature`
 5. Create new pull request.
+
+## Testing
+
+The tests make live network calls so you'll need to ensure that you're logged into your Heroku account. You'll also need an application that uses a set of Heroku's features, if you don't have one you can create one. E.g.
+
+```
+$ git clone https://github.com/heroku/ruby-getting-started.git
+$ cd ruby-getting-started/
+$ heroku create <memorable-name-here>
+$ heroku webhooks:add -i api:dyno -l notify -u https://example.com/hooks
+$ git push heroku master
+```
+Now you can specify your app name while you run tests:
+
+```
+$ TEST_APP_NAME="<memorable-name-here>" rspec ./spec
+```

--- a/spec/acceptance/generated_client_spec.rb
+++ b/spec/acceptance/generated_client_spec.rb
@@ -7,7 +7,7 @@ describe 'The generated platform api client' do
   end
 
   it "can get addon info for an app" do
-    expect(client.addon.list_by_app(an_app['name'])).not_to be_empty
+    expect(client.addon.list_by_app(app_name)).not_to be_empty
   end
 
   it "can list apps" do
@@ -15,22 +15,23 @@ describe 'The generated platform api client' do
   end
 
   it "can get app info" do
-    expect(client.app.info(an_app['name'])).to eq an_app
+    app_info = client.app.info(app_name)
+    expect(app_info['name']).to eq app_name
   end
 
   it "can get build info" do
-    expect(client.build.list(an_app['name'])).not_to be_empty
+    expect(client.build.list(app_name)).not_to be_empty
   end
 
   it "can get config vars" do
-    expect(client.config_var.info_for_app(an_app['name'])).not_to be_empty
+    expect(client.config_var.info_for_app(app_name)).not_to be_empty
   end
 
   it "can get domain list and info" do
-    domains = client.domain.list(an_app['name'])
+    domains = client.domain.list(app_name)
     expect(domains).not_to be_empty
 
-    expect(client.domain.info(an_app['name'], domains.first['hostname'])).not_to be_empty
+    expect(client.domain.info(app_name, domains.first['hostname'])).not_to be_empty
   end
 
   it "can get dyno sizes" do
@@ -42,11 +43,15 @@ describe 'The generated platform api client' do
   end
 
   it "can get release info" do
-    expect(client.release.list(an_app['name'])).not_to be_empty
+    expect(client.release.list(app_name)).not_to be_empty
   end
 
   it "can get app webhooks" do
-    expect(client.app_webhook.list(an_app['name'])).not_to be_empty
+    expect(client.app_webhook.list(app_name)).not_to be_empty
+  end
+
+  def app_name
+    ENV["TEST_APP_NAME"] || an_app['name']
   end
 
   def an_app


### PR DESCRIPTION
Previously running tests depended on a user's applications having a certain set of features, such as webhooks.
These features aren't guaranteed on every application and can cause tests to fail for different users.

With this commit users can now specify an explicit app name while running tests so that there is consistent behaviour.