### PR TITLE
Add rate throttling logic to PlatformAPI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,28 +2,34 @@ PATH
   remote: .
   specs:
     platform-api (2.2.0)
-      heroics (~> 0.0.25)
+      heroics (~> 0.1.1)
       moneta (~> 1.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     coderay (1.1.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     erubis (2.7.0)
-    excon (0.62.0)
-    heroics (0.0.25)
+    excon (0.67.0)
+    hashdiff (1.0.0)
+    heroics (0.1.1)
       erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
     method_source (0.9.0)
     moneta (1.0.0)
-    multi_json (1.13.1)
+    multi_json (1.14.1)
     netrc (0.11.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    public_suffix (4.0.1)
     rake (12.3.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -38,19 +44,25 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    safe_yaml (1.0.5)
+    webmock (3.7.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     yard (0.9.16)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.3)
+  bundler
   netrc
   platform-api!
   pry
   rake
   rspec
+  webmock
   yard
 
 BUNDLED WITH
-   1.16.4
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -318,6 +318,14 @@ To disable this retry and sleep behavior set the env var`PLATFORM_API_DISABLE_RA
 
 For more information about this algorithm and behavior see [Rate Limit GCRA client demo](https://github.com/schneems/rate-limit-gcra-client-demo).
 
+By default rate throttling will log to STDOUT when the sleep/retry behavior is triggered. To add your own custom logging, for example to librato or honeycomb, you can pass in a callable object that takes three arguments:
+
+```ruby
+PlatformAPI.rate_throttle.log = ->(event_type, request, throttle_object) {
+  # Your logic here
+}
+```
+
 ## Building and releasing
 
 ### Generate a new client

--- a/README.md
+++ b/README.md
@@ -308,6 +308,16 @@ Connect to a different host by passing a `url` option:
 client = PlatformAPI.connect('my-api-key', url: 'https://api.example.com')
 ```
 
+### Rate throttling
+
+By default client requests from this library will respect Heroku's rate-limiting. The client can make as many requests as possible until Heroku's server says that it has gone over. Once a request has been rate-limited the client will sleep and then retry the request again. This process will repeat until the request is successful.
+
+Once a single request has been rate-limited, the client will auto-tune a sleep value so that future requests are less likely to be rate-limited by the server.
+
+To disable this retry and sleep behavior set the env var`PLATFORM_API_DISABLE_RATE_THROTTLE=1`.
+
+For more information about this algorithm and behavior see [Rate Limit GCRA client demo](https://github.com/schneems/rate-limit-gcra-client-demo).
+
 ## Building and releasing
 
 ### Generate a new client

--- a/config/client-config.rb
+++ b/config/client-config.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 require 'heroics'
 require File.join(File.expand_path('../..', __FILE__), 'lib', 'platform-api', 'version.rb')
+require File.join(File.expand_path('../..', __FILE__), 'lib', 'platform-api', 'heroku_client_throttle.rb')
 
 Heroics.default_configuration do |config|
   config.base_url = 'https://api.heroku.com'
   config.module_name = 'PlatformAPI'
   config.schema_filepath = File.join(File.expand_path('../..', __FILE__), 'schema.json')
+  config.rate_throttle = PlatformAPI::HerokuClientThrottle.new unless ENV['PLATFORM_API_DISABLE_RATE_THROTTLE']
+  config.acceptable_status_codes = [429]
 
   config.headers = {
     'Accept'      => 'application/vnd.heroku+json; version=3',

--- a/config/client-config.rb
+++ b/config/client-config.rb
@@ -7,8 +7,13 @@ Heroics.default_configuration do |config|
   config.base_url = 'https://api.heroku.com'
   config.module_name = 'PlatformAPI'
   config.schema_filepath = File.join(File.expand_path('../..', __FILE__), 'schema.json')
-  config.rate_throttle = PlatformAPI::HerokuClientThrottle.new unless ENV['PLATFORM_API_DISABLE_RATE_THROTTLE']
-  config.acceptable_status_codes = [429]
+
+  unless ENV['PLATFORM_API_DISABLE_RATE_THROTTLE']
+    PlatformAPI.rate_throttle = PlatformAPI::HerokuClientThrottle.new
+
+    config.rate_throttle = PlatformAPI.rate_throttle
+    config.acceptable_status_codes = [429]
+  end
 
   config.headers = {
     'Accept'      => 'application/vnd.heroku+json; version=3',

--- a/lib/platform-api.rb
+++ b/lib/platform-api.rb
@@ -1,10 +1,21 @@
 require 'heroics'
 require 'moneta'
 
-require_relative '../config/client-config'
 # Ruby HTTP client for the Heroku API.
 module PlatformAPI
+  def self.rate_throttle=(rate_throttle)
+    @rate_throttle = rate_throttle
+  end
+
+  # Get access to the rate throttling class object for configuration.
+  #
+  # @return [PlatformAPI::HerokuClientThrottle]
+  def self.rate_throttle
+    @rate_throttle
+  end
 end
+
+require_relative '../config/client-config'
 
 require 'platform-api/client'
 require 'platform-api/version'

--- a/lib/platform-api.rb
+++ b/lib/platform-api.rb
@@ -8,3 +8,4 @@ end
 
 require 'platform-api/client'
 require 'platform-api/version'
+require 'platform-api/heroku_client_throttle'

--- a/lib/platform-api/heroku_client_throttle.rb
+++ b/lib/platform-api/heroku_client_throttle.rb
@@ -1,0 +1,123 @@
+require 'thread'
+
+module PlatformAPI
+  # This class is responsible for making sure requests
+  # to the Heroku API do not fail, and do not do not
+  # cause excess burden to the API server by delaying
+  # requests and spreading them over time.
+  #
+  # If a request is rate limited, this class will
+  # automatically retry the request.
+  #
+  # High level logic:
+  #   - When a rate limit event occurs, double the amount
+  #     of time the client sleeps for
+  #   - When a request is successful reduce the amount of
+  #     of time the client sleeps for by a small amount
+  #
+  # This logic loosely mimics "congestion avoidance" in TCP.
+  #
+  # Example Usage:
+  #
+  #   client = HerokuClientThrottle.new
+  #   request = client.call { Excon.get("https://api.heroku.com/<path>")}
+  #   request.status #=> 200
+  #
+  class HerokuClientThrottle
+    MAX_LIMIT = 4500.to_f
+    MIN_SLEEP = 1/(MAX_LIMIT / 3600)
+    MIN_SLEEP_OVERTIME_PERCENT = 1.0 - 0.9 # Allow min sleep to go lower than actually calculated value, must be less than 1
+
+    attr_reader :rate_limit_multiply_at, :sleep_for, :rate_limit_count, :log, :mutex
+
+    def initialize(log = ->(req, throttle) {})
+      @mutex = Mutex.new
+      @sleep_for = 2 * MIN_SLEEP
+      @rate_limit_count = 0
+      @times_retried = 0
+      @retry_thread = nil
+      @min_sleep_bound = MIN_SLEEP * MIN_SLEEP_OVERTIME_PERCENT
+      @rate_multiplier = 1
+      @rate_limit_multiply_at = Time.now - 1800
+      @log = log
+    end
+
+    def jitter
+      sleep_for * rand(0.0..0.1)
+    end
+
+    def call(&block)
+      sleep(sleep_for + jitter) unless @rate_limit_count.zero?
+
+      req = yield
+
+      log.call(req, self)
+
+      if retry_request?(req)
+        req = retry_request_logic(req, &block)
+        return req
+      else
+        decrement_logic(req)
+        return req
+      end
+    end
+
+    def decrement_amount(req, time_now = Time.now)
+      ratelimit_remaining = req.headers["RateLimit-Remaining"].to_i
+
+      # The goal of this logic is to balance out rate limiting events,
+      # to prevent one single "flappy" client.
+      #
+      # When a client was recently rate limitied the time factor will be high.
+      # This is used to slow down the decrement logic so that other clients that
+      # have not hit a rate limit in a long time can come down.
+      # Equation is based on exponential decay
+      seconds_since_last_multiply = (time_now - self.rate_limit_multiply_at) + 1 # avoid case where current time is also recorded multiply time
+      time_factor = 1.0/(1.0 - Math::E ** -(seconds_since_last_multiply/4500.0))
+
+      return (ratelimit_remaining*self.sleep_for)/(time_factor*MAX_LIMIT)
+    end
+
+    def decrement_logic(req)
+      @mutex.synchronize do
+        @sleep_for -= decrement_amount(req)
+        @sleep_for = @min_sleep_bound if @sleep_for < @min_sleep_bound
+      end
+    end
+
+    def retry_request_logic(req, &block)
+      @mutex.synchronize do
+        if @retry_thread.nil? || @retry_thread == Thread.current
+          @rate_multiplier = req.headers.fetch("RateLimit-Multiplier") { @rate_multiplier }.to_f
+          @min_sleep_bound = (1/(@rate_multiplier * MAX_LIMIT / 4500))
+          @min_sleep_bound *= MIN_SLEEP_OVERTIME_PERCENT
+          @rate_limit_count += 1
+
+          # First retry request, only increase sleep value if retry doesn't work.
+          # Should guard against run-away high sleep values
+          if @times_retried != 0
+            @sleep_for *= 2
+            @rate_limit_multiply_at = Time.now
+          end
+
+          @times_retried += 1
+          @retry_thread = Thread.current
+        end
+      end
+
+      # Retry the request with the new sleep value
+      req = call(&block)
+      if @retry_thread == Thread.current
+        @mutex.synchronize do
+          @times_retried = 0
+          @retry_thread = nil
+        end
+      end
+      return req
+    end
+
+    def retry_request?(req)
+      req.status == 429
+    end
+  end
+end

--- a/platform-api.gemspec
+++ b/platform-api.gemspec
@@ -19,13 +19,15 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep('^(test|spec|features)/')
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'netrc'
   spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'webmock'
 
-  spec.add_dependency 'heroics', '~> 0.0.25'
+
+  spec.add_dependency 'heroics', '~> 0.1.1'
   spec.add_dependency 'moneta', '~> 1.0.0'
 end

--- a/spec/acceptance/generated_client_spec.rb
+++ b/spec/acceptance/generated_client_spec.rb
@@ -1,7 +1,27 @@
 require 'netrc'
 require 'platform-api'
+require 'webmock/rspec'
+
+include WebMock::API
+WebMock.allow_net_connect!
 
 describe 'The generated platform api client' do
+  it "works even if first request is rate limited" do
+    WebMock.enable!
+    url = "https://api.heroku.com/apps"
+    stub_request(:get, url)
+      .to_return([
+        {status: 429},
+        {status: 200}
+      ])
+
+    client.app.list
+
+    expect(WebMock).to have_requested(:get, url).twice
+  ensure
+    WebMock.disable!
+  end
+
   it "can get account info" do
     expect(client.account.info).not_to be_empty
   end
@@ -11,7 +31,7 @@ describe 'The generated platform api client' do
   end
 
   it "can list apps" do
-    expect(client.app.list).not_to be_empty
+    expect(client.app.list.to_a).not_to be_empty
   end
 
   it "can get app info" do
@@ -55,7 +75,7 @@ describe 'The generated platform api client' do
   end
 
   def an_app
-    @app ||= client.app.list.first
+    @app ||= client.app.list.to_a.first
   end
 
   def email

--- a/spec/unit/heroku_client_throttle_spec.rb
+++ b/spec/unit/heroku_client_throttle_spec.rb
@@ -1,0 +1,117 @@
+require 'platform-api'
+
+class FakeResponse
+  attr_reader :status, :headers
+
+  def initialize(status = 200, remaining = 10)
+    @status = status
+
+    @headers = {
+      "RateLimit-Remaining" => remaining,
+      "RateLimit-Multiplier" => 1,
+      "Content-Type" => "text/plain".freeze
+    }
+  end
+end
+
+describe 'Heroku client throttle' do
+  it "Check when rate limit is triggered, the time since multiply changes" do
+    client = PlatformAPI::HerokuClientThrottle.new
+    def client.sleep(val); end;
+
+    sleep_start = client.sleep_for
+    multiply_at_start = client.rate_limit_multiply_at
+
+    @times_called = 0
+    client.call do
+      @times_called += 1
+      if client.rate_limit_count < 2
+        FakeResponse.new(429)
+      else
+        FakeResponse.new
+      end
+    end
+
+    sleep_end = client.sleep_for
+    multiply_at_end = client.rate_limit_multiply_at
+
+    expect(@times_called).to eq(3) # Once for initial 429, once for second 429, once for final 200
+    expect(sleep_end).to be_between(sleep_start, sleep_start * 2.1)
+    expect(multiply_at_end).to_not eq(multiply_at_start)
+    expect(multiply_at_end).to be_between(multiply_at_start, Time.now)
+  end
+
+  describe "decrement" do
+    it "makes sleep_for go down faster when rate_limit_multiply_at is higher" do
+      client = PlatformAPI::HerokuClientThrottle.new
+      def client.sleep(val); end;
+
+      @mock_time = Time.now
+
+      allow(client).to receive(:rate_limit_multiply_at) { @mock_time }
+      decrement_one = client.decrement_amount(FakeResponse.new, @mock_time)
+
+      allow(client).to receive(:rate_limit_multiply_at) { @mock_time - 200 }
+      decrement_two = client.decrement_amount(FakeResponse.new, @mock_time)
+
+      allow(client).to receive(:rate_limit_multiply_at) { @mock_time - 2000 }
+      decrement_three = client.decrement_amount(FakeResponse.new, @mock_time)
+
+      expect(decrement_one < decrement_two).to be_truthy
+      expect(decrement_two < decrement_three).to be_truthy
+    end
+
+    it "makes sleep_for go down faster when remaining is higher" do
+      client = PlatformAPI::HerokuClientThrottle.new
+      @mock_time = Time.now
+
+      remaining = 1
+      decrement_one = client.decrement_amount(FakeResponse.new(200, remaining), @mock_time)
+
+      remaining = 100
+      decrement_two = client.decrement_amount(FakeResponse.new(200, remaining), @mock_time)
+
+      remaining = 1000
+      decrement_three = client.decrement_amount(FakeResponse.new(200, remaining), @mock_time)
+
+      expect(decrement_one < decrement_two).to be_truthy
+      expect(decrement_two < decrement_three).to be_truthy
+    end
+
+    it "sleep_for causes proportional rate reduction" do
+      client = PlatformAPI::HerokuClientThrottle.new
+      @mock_time = Time.now
+
+      def client.sleep_for; 1; end
+      decrement_one = client.decrement_amount(FakeResponse.new, @mock_time)
+
+      client = PlatformAPI::HerokuClientThrottle.new
+      def client.sleep_for; 10; end
+      decrement_two = client.decrement_amount(FakeResponse.new, @mock_time)
+
+      expect(decrement_one < decrement_two).to be_truthy
+
+      expect(decrement_two).to be_between(decrement_one * 9.9, decrement_one * 10.1)
+    end
+
+    it "does not start rate limiting until the client detects a limit" do
+      client = PlatformAPI::HerokuClientThrottle.new
+      def client.sleep(val); raise "Should not be called"; end
+      client.call do
+        FakeResponse.new
+      end
+    end
+
+    it "does start rate limiting once the client detects a limit" do
+      client = PlatformAPI::HerokuClientThrottle.new
+      expect(client).to receive(:sleep).exactly(1).times
+      client.call do
+        if client.rate_limit_count < 1
+          FakeResponse.new(429)
+        else
+          FakeResponse.new
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
By default when you get a rate-limit event while using the platform-api the method call will fail. Since there's no feedback built into the client, another call might be attempted (for example if the API is being hit via a background worker). This is bad for Heroku because it means we now are seeing a stream of requests that will never complete (because of the rate limit) and it is bad for the end-user because they have a flurry of errors that are unexpected and unhandled.

This PR builds on top of the project https://github.com/schneems/rate-limit-gcra-client-demo to automatically find a value that the client can sleep for so that it can maximize throughput while still minimizing the number of requests that are rate limited.

At a high level when it sees a 429 response from the server, it will sleep and then retry the response. If it gets another 429 then the sleep amount will be multiplicatively increased until it can make a successful request.

As the client is able to make successful requests the amount of sleep time is reduced by a subtractive amount based off of the current number of requests allowed (as reported by the server), the amount of time since the last rate limit event, and it's current value.

This logic somewhat mirrors TCP "slow start" behavior (though in reverse). 

In simulations, over time we end up seeing from 2-3% of requests rate limited.

![](https://github.com/schneems/rate-limit-gcra-client-demo/raw/master/chart.png)

> Graph from README of the simulation readme

This PR has been built on the work of other changes added to heroics:

- https://github.com/interagent/heroics/pull/95
- https://github.com/interagent/heroics/pull/96

## Discussion

In addition to the implementation, the one last unknown is what the default logging behavior should be. While rate-throttling by default provides a good experience, we need to provide feedback to the user letting them know that it is happening.

This PR was paired with @lolaodelola