### PR TITLE
Enable rate-throttling by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 3.0.0
 
-- Rate throttling is on by default.
+- Rate throttling is on by default. (https://github.com/heroku/platform-api/pull/104)
 
 ## 2.3.0
 
-- Changes are now tracked in the CHANGELOG.md
-- Rate throttling is included by default but disabled.
+- Changes are now tracked in the CHANGELOG.md.
+- Rate throttling is included by default but disabled. (https://github.com/heroku/platform-api/pull/103)

--- a/config/client-config.rb
+++ b/config/client-config.rb
@@ -9,16 +9,7 @@ Heroics.default_configuration do |config|
   config.module_name = 'PlatformAPI'
   config.schema_filepath = File.join(File.expand_path('../..', __FILE__), 'schema.json')
 
-  PlatformAPI.rate_throttle = ->(&block) {
-    @deprecate_on_first ||= begin
-      message = String.new("[Warning] Starting in PlatformAPI version 3+, requests will include rate throttling logic\n")
-      message << "to opt-out of this behavior set: `PlatformAPI.rate_throttle = RateThrottleClient::Null.new`\n"
-      message << "to silence this warning and opt-in to this logic, upgrade to PlatformAPI version 3+"
-      warn message
-      true
-    end
-    block.call
-  }
+  PlatformAPI.rate_throttle = RateThrottleClient::ExponentialIncreaseProportionalRemainingDecrease.new
   config.rate_throttle = PlatformAPI.rate_throttle
   config.acceptable_status_codes = [429]
 

--- a/lib/platform-api/client.rb
+++ b/lib/platform-api/client.rb
@@ -83,7 +83,7 @@ module PlatformAPI
 
   # Get the default options.
   def self.default_options
-    default_headers = {"Accept"=>"application/vnd.heroku+json; version=3", "User-Agent"=>"platform-api/2.3.0"}
+    default_headers = {"Accept"=>"application/vnd.heroku+json; version=3", "User-Agent"=>"platform-api/3.0.0.pre.1"}
     {
       default_headers: default_headers,
       url:             "https://api.heroku.com"

--- a/lib/platform-api/version.rb
+++ b/lib/platform-api/version.rb
@@ -1,3 +1,3 @@
 module PlatformAPI
-  VERSION = '2.3.0.pre.2'
+  VERSION = '3.0.0.pre.1'
 end

--- a/spec/acceptance/config_spec.rb
+++ b/spec/acceptance/config_spec.rb
@@ -11,7 +11,7 @@ describe 'Platform API config' do
       @original_rate_throttle = rate_throttle.dup
 
       # No junk in test dots
-      rate_throttle.log = ->(*_) {} if rate_throttle.respond_to?("log=")
+      rate_throttle.log = ->(*_) {}
 
       # Don't sleep in tests
       def rate_throttle.sleep(value); end
@@ -24,8 +24,6 @@ describe 'Platform API config' do
     end
 
     it "works even if first request is rate limited" do
-      skip("Default behavior changes in v3+") unless Gem::Version.new(PlatformAPI::VERSION) >= Gem::Version.new("3.0.0.beta")
-
       stub_request(:get, "https://api.heroku.com/apps")
         .to_return([
           {status: 429},
@@ -46,10 +44,6 @@ describe 'Platform API config' do
         ])
 
       @retry_count = 0
-      throttle = RateThrottleClient::ExponentialIncreaseProportionalRemainingDecrease.new
-      def throttle.sleep(var); end
-
-      PlatformAPI.rate_throttle = throttle
       PlatformAPI.rate_throttle.log = ->(*_) { @retry_count += 1 }
       client.app.list
 


### PR DESCRIPTION
As a followup from https://github.com/heroku/platform-api/pull/103 this PR bumps the major `platform-api` version and enables rate-throttling by default.

The idea is that we'll release 2.3.0 and then merge and release this PR for 3.0.0 back to back so there's a deprecation and a version to upgrade to.