### PR TITLE
[changelog skip] Fix require problem and test it

### DIFF
--- a/config/client-config.rb
+++ b/config/client-config.rb
@@ -2,7 +2,7 @@
 require 'heroics'
 require 'rate_throttle_client'
 
-require File.join(File.expand_path('../..', __FILE__), 'lib', 'platform-api')
+require_relative '../lib/platform-api.rb'
 
 Heroics.default_configuration do |config|
   config.base_url = 'https://api.heroku.com'

--- a/lib/platform-api.rb
+++ b/lib/platform-api.rb
@@ -1,5 +1,6 @@
 require 'heroics'
 require 'moneta'
+require 'platform-api/version'
 
 # Ruby HTTP client for the Heroku API.
 module PlatformAPI
@@ -18,4 +19,3 @@ end
 
 require_relative '../config/client-config'
 require 'platform-api/client'
-require 'platform-api/version'

--- a/lib/platform-api/version.rb
+++ b/lib/platform-api/version.rb
@@ -1,3 +1,3 @@
 module PlatformAPI
-  VERSION = '2.3.0.pre.1'
+  VERSION = '2.3.0.pre.2'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require "bundler/setup"
+
 require 'pry'
 require 'webmock/rspec'
 require 'platform-api'


### PR DESCRIPTION
When I released the pre-release version 2.3.0.pre.1 it fails when running:

```
gem install platform-api --pre
$ ruby -e 'require "platform-api"'
Loading file /Users/rschneeman/.gem/ruby/2.7.1/gems/platform-api-2.3.0.pre.1/lib/platform-api.rb
Loading file /Users/rschneeman/.gem/ruby/2.7.1/gems/platform-api-2.3.0.pre.1/config/client-config.rb
Traceback (most recent call last):
	2: from -e:1:in `<main>'
	1: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
/Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require': cannot load such file -- platform-api (LoadError)
	9: from -e:1:in `<main>'
	8: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:156:in `require'
	7: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:168:in `rescue in require'
	6: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:168:in `require'
	5: from /Users/rschneeman/.gem/ruby/2.7.1/gems/platform-api-2.3.0.pre.1/lib/platform-api.rb:20:in `<top (required)>'
	4: from /Users/rschneeman/.gem/ruby/2.7.1/gems/platform-api-2.3.0.pre.1/lib/platform-api.rb:20:in `require_relative'
	3: from /Users/rschneeman/.gem/ruby/2.7.1/gems/platform-api-2.3.0.pre.1/config/client-config.rb:9:in `<top (required)>'
	2: from /Users/rschneeman/.gem/ruby/2.7.1/gems/heroics-0.1.1/lib/heroics.rb:16:in `default_configuration'
	1: from /Users/rschneeman/.gem/ruby/2.7.1/gems/heroics-0.1.1/lib/heroics.rb:16:in `tap'
/Users/rschneeman/.gem/ruby/2.7.1/gems/platform-api-2.3.0.pre.1/config/client-config.rb:29:in `block in <top (required)>': uninitialized constant PlatformAPI::VERSION (NameError)
```

This failure wasn't showing up in the tests because the file `lib/platform-api/version.rb` is manually being loaded in the Gemspec which is executed before specs.

To test this behavior (of requiring the lib from a new project) we can use an unbundled env and manually set the require path:

```
`ruby -I#{File.join(__dir__, "../../lib")} -e "require 'platform-api'" 2>&1`
```