### PR TITLE
Bump heroics to 0.1.2 for Ruby 3 compatibility

### DIFF
--- a/platform-api.gemspec
+++ b/platform-api.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'heroku_hatchet'
   spec.add_development_dependency 'webmock'
 
-  spec.add_dependency 'heroics', '~> 0.1.1'
+  spec.add_dependency 'heroics', '~> 0.1.2'
   spec.add_dependency 'moneta', '~> 1.0.0'
   spec.add_dependency 'rate_throttle_client', '~> 0.1.0'
 end


### PR DESCRIPTION
Running a Ruby 3 application with the `platform-api` gem can fail with an error like this:

```
LoadError:
  cannot load such file -- webrick
# ./config/environment.rb:8:in `require'
# ./config/environment.rb:8:in `<top (required)>'
```

This is because the gem relies on `heroics` 0.1.1, which in turn relies on `webrick` but does not have it in its gemspec. Ruby 3 no longer includes `webrick` by default, so it needs to be explicitly added as a dependency. This work was done in https://github.com/interagent/heroics/pull/102 and released under `heroics` 0.1.2. Bumping the version here should solve the problem with using `platform-api` with Ruby 3.