### PR TITLE
Fix typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Master (unreleased)
 
-## 3.6.0
+## 3.7.0
 
 - Pull latest JSON Schema and regenerated API.
 


### PR DESCRIPTION
Little gotcha in the version, 3.6.0 is written twice