### PR TITLE
[changelog skip] Updated CI to run with currently supported ruby versions & other hatchet improvements

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '3.0', '3.1', '3.2', '3.3' ]
+        ruby: [ '3.2', '3.3', '3.4', '4.0' ]
     env:
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
       HEROKU_API_USER: ${{ secrets.HEROKU_API_USER }}

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -21,8 +21,10 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
 
+      - name: "Set bundler path"
+        run: bundle config set path 'vendor/bundle'
       - name: "Install dependencies"
-        run: bundle install --jobs=4 --retry=3 --path vendor/bundle
+        run: bundle install --jobs=4 --retry=3
       - name: "Hatchet setup"
         run: bundle exec hatchet ci:setup
       - name: "Run tests"

--- a/spec/acceptance/generated_client_spec.rb
+++ b/spec/acceptance/generated_client_spec.rb
@@ -5,6 +5,10 @@ describe 'The generated platform api client' do
     @app_name = ENV["TEST_APP_NAME"] || hatchet_app.name
   end
 
+  after(:all) do
+    hatchet_app.teardown!
+  end
+
   def app_name
     @app_name
   end

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -1,7 +1,8 @@
 module PlatformAPI::SpecHelperMethods
   def hatchet_app
+    config = { "FOO" => "bar" }
     @hatchet_app ||= begin
-      app = Hatchet::Runner.new("default_ruby", buildpacks: ["heroku/ruby"])
+      app = Hatchet::Runner.new("default_ruby", buildpacks: ["heroku/ruby"], config: config)
       app.in_directory do
         app.setup!
         app.push_with_retry!


### PR DESCRIPTION
## Summary

This PR updates the ruby versions used in the CI to the currently supported Ruby versions https://www.ruby-lang.org/en/downloads/branches/ 

This PR also:
- Updates the hatchet app created in the tests to have config var `FOO=bar` set on creation
- Adds a teardown! method in the test file to ensure hatchet apps are deleted after testing