### PR TITLE
Replace deprecated MultiJson constant with JSON.parse

### DIFF
--- a/lib/platform-api/client.rb
+++ b/lib/platform-api/client.rb
@@ -3719,7 +3719,7 @@ module PlatformAPI
     end
   end
 
-  SCHEMA = Heroics::Schema.new(MultiJson.load(<<-'HEROICS_SCHEMA'))
+  SCHEMA = Heroics::Schema.new(JSON.parse(<<-'HEROICS_SCHEMA'))
 {
   "$schema": "http://interagent.github.io/interagent-hyper-schema",
   "type": [


### PR DESCRIPTION
## What

Replace the deprecated `MultiJson` constant with `JSON.parse` in the generated client.

## Why

The `multi_json` gem in its 1.21.x line deprecated the CamelCase `MultiJson` constant in favor of `MultiJSON` (all-caps), and will remove it entirely in v2.0. As a result, simply loading `platform-api` now emits a deprecation warning on every Ruby process:

```
The MultiJson constant is deprecated and will be removed in v2.0. Use MultiJSON instead.
```

This affects every downstream consumer of `platform-api` — the warning is emitted whether or not you ever call the Heroku API in your process.

## Approach

The generator (`heroics`) has already fixed this upstream:

- `heroics 0.1.3` template emits `MultiJson.load(...)`
- `heroics 0.1.4` template emits `JSON.parse(...)` and removed its `multi_json` dependency entirely ([CHANGELOG](https://github.com/interagent/heroics/blob/main/CHANGELOG.md))

The `platform-api` gemspec already allows `heroics ~> 0.1.1`, so the long-term fix is just `bundle update heroics && rake build`. However, that produces a noisy ~1,900-line whitespace-only diff (heroics 0.1.4 also tweaked template whitespace), which is hard to review.

This PR applies the **single substantive change** — `MultiJson.load` → `JSON.parse` — directly so the deprecation warning goes away immediately without the whitespace churn. The next time someone runs `rake build` against `heroics >= 0.1.4`, the regenerated file will produce the same line.

## Compatibility

- `JSON.parse` is part of the Ruby standard library — no new dependency.
- Behavior is identical: both calls parse the embedded JSON schema literal at gem load time.
- No API changes for consumers.
