### PR TITLE
Bumps moneta to 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Main (unreleased)
 
+- Relax `moneta` constraint from `~> 1.0.0` to `~> 1.0` so users can pick up moneta 1.x releases (currently 1.6.0). Resolves a 6.0 libyear gap on transitive dependencies. The Moneta API used by this gem (`Moneta.new(:File, dir: ...)`) is unchanged.
+
 ## 3.9.1
 
 - Fix `NameError: uninitialized constant PlatformAPI::MultiJson` caused by heroics 0.1.4 dropping its multi_json dependency. Uses `JSON.parse` from the standard library instead. (#152)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Main (unreleased)
 
-- Relax `moneta` constraint from `~> 1.0.0` to `~> 1.0` so users can pick up moneta 1.x releases (currently 1.6.0). Resolves a 6.0 libyear gap on transitive dependencies. The Moneta API used by this gem (`Moneta.new(:File, dir: ...)`) is unchanged.
+- Relax `moneta` constraint from `~> 1.0.0` to `~> 1.0`
 
 ## 3.9.1
 

--- a/platform-api.gemspec
+++ b/platform-api.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock'
 
   spec.add_dependency 'heroics', '~> 0.1.1'
-  spec.add_dependency 'moneta', '~> 1.0.0'
+  spec.add_dependency 'moneta', '~> 1.0'
   spec.add_dependency 'rate_throttle_client', '~> 0.1.0'
 end


### PR DESCRIPTION
The `moneta` gem is pinned to `~> 1.0.0`, which only allows 1.0.x. moneta 1.0.0 was released 2017-03-08; moneta 1.6.0 (2023-03-13) is the current release. For consumers of `platform-api`, this single transitive dependency accounts for ~6 libyears of staleness.

https://github.com/moneta-rb/moneta/blob/v1.6.0/CHANGES

_Authored with Claude Code._